### PR TITLE
Properly return installed games on Windows

### DIFF
--- a/resources/registry.py
+++ b/resources/registry.py
@@ -62,12 +62,9 @@ def get_registry_values(registry_path):
                 app_id = _winreg.EnumKey(apps, i)
                 #print(app_id)
                 installed = is_installed(app_id)
-                if installed is None:
-                    i += 1
-                    continue
-                else:
+                i += 1
+                if installed:
                     app_dict[app_id] = installed
-                    i += 1
 
         except WindowsError:
             pass


### PR DESCRIPTION
Fixes #17 .

As mentioned there, I kept the original function structure and return values (ie `get_registry_values` returns a dict of installed games only, even though the registry contains uninstalled game keys.) , but the name is a bit confusing considering what the function actually does.


If it seems good to you, I'd recommend refactoring `get_registry_values` to actually return a dict of all Steam registry values, differently on Windows and Linux. Then a `get_installed_games` function would call `get_registry_values `and filter the dict of games, keeping only the installed ones. That should improve clarity and also reduce a bit the amount of code to maintain differently between Windows and Linux. 

Just a suggestion of course, no worries if you feel like it's fine as it is :)  