### PR TITLE
More arts types

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.steam.library" name="Steam Library" version="0.6.3" provider-name="aanderse">
+<addon id="plugin.program.steam.library" name="Steam Library" version="0.7.0" provider-name="aanderse">
     <requires>
         <import addon="xbmc.python" version="2.19.0" />
         <import addon="script.module.requests" version="2.18.4" />
+        <import addon="script.module.requests-cache" version="0.4.13" />
         <import addon="script.module.routing" version="0.2.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon.py">

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -28,7 +28,7 @@ STEAM_ARTS_TYPES = {  # img_icon_path is provided by steam API to get the icon. 
     'header': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg',
     'generated_bg': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/page_bg_generated_v6b.jpg',  # Auto generated background with a shade of blue.
     'icon': 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{appid}/{img_icon_path}.jpg',
-    'logo': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/logo.png'  # Can return 404
+    'clearlogo': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/logo.png'  # Can return 404
 }
 
 # Dictionary containing for each art type, a url for the art (to format with appid / img_icon_path afterwards), and a fallback art type.
@@ -42,7 +42,7 @@ ARTS_ASSIGNMENTS = {
     'landscape': {'url': STEAM_ARTS_TYPES['header'], 'fallback': None},
     'thumb': {'url': STEAM_ARTS_TYPES['header'], 'fallback': None},
     'icon': {'url': STEAM_ARTS_TYPES['icon'], 'fallback': None},
-    'clearlogo': {'url': STEAM_ARTS_TYPES['logo'], 'fallback': None}
+    'clearlogo': {'url': STEAM_ARTS_TYPES['clearlogo'], 'fallback': None}
 }
 
 

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -2,6 +2,7 @@ import xbmc
 import xbmcaddon
 
 import os
+from datetime import timedelta
 import requests
 import requests_cache
 
@@ -9,14 +10,14 @@ from util import log
 
 __addon__ = xbmcaddon.Addon()
 artFallbackEnabled = __addon__.getSetting("enable-art-fallback") == 'true'  # Kodi stores boolean settings as strings
-minutesBeforeArtsExpiration = int(__addon__.getSetting("arts-expire-after-minutes"))  # Default is 2 months
+monthsBeforeArtsExpiration = int(__addon__.getSetting("arts-expire-after-months"))  # Default is 2 months
 
 # define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
 addonUserDataFolder = xbmc.translatePath(__addon__.getAddonInfo('profile'))
 ART_AVAILABILITY_CACHE_FILE = xbmc.translatePath(os.path.join(addonUserDataFolder, 'requests_cache_arts'))
 
 cached_requests = requests_cache.core.CachedSession(ART_AVAILABILITY_CACHE_FILE, backend='sqlite',
-                                                    expire_after=60 * minutesBeforeArtsExpiration,
+                                                    expire_after= timedelta(weeks=4*monthsBeforeArtsExpiration),
                                                     allowable_methods=('HEAD',), allowable_codes=(200, 404),
                                                     old_data_on_error=True,
                                                     fast_save=True)

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -8,7 +8,7 @@ import requests_cache
 from util import show_error
 
 __addon__ = xbmcaddon.Addon()
-enableArtFallback = __addon__.getSetting("enable-art-fallback") == 'true'  # Kodi stores boolean settings as strings
+artFallbackEnabled = __addon__.getSetting("enable-art-fallback") == 'true'  # Kodi stores boolean settings as strings
 minutesBeforeArtsExpiration = int(__addon__.getSetting("arts-expire-after-minutes"))  # Default is 2 months
 
 # define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
@@ -17,68 +17,75 @@ ART_AVAILABILITY_CACHE_FILE = xbmc.translatePath(os.path.join(addonUserDataFolde
 
 cached_requests = requests_cache.core.CachedSession(ART_AVAILABILITY_CACHE_FILE, backend='sqlite',
                                                     expire_after=60 * minutesBeforeArtsExpiration,
-                                                    allowable_methods=('HEAD',),
-                                                    allowable_codes=(200, 404),
+                                                    allowable_methods=('HEAD',), allowable_codes=(200, 404),
                                                     old_data_on_error=True,
                                                     fast_save=True)
 
-# Todo : tweak fallbacks and arts to have the best look in Kodi
-#  TODO note which are safe to use and which can be missing
-
 # Dictionary containing for each art type, a base_url for the art (to format with appid / img_icon_path afterwards), and a fallback art type.
-arts_urls = {  # {0} is appid, {1} is a special path provided by steam api for the icon
-    'poster': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_600x900.jpg', 'fallback_media': 'landscape'},
-    'banner': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_hero.jpg', 'fallback_media': 'landscape'},
-    'landscape': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': None},
-    'thumb': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': None},
-    'fanart': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_hero.jpg', 'fallback_media': 'fanart2'},
-    'fanart2': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': 'fanart3'},
-    'fanart3': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/page_bg_generated_v6b.jpg', 'fallback_media': None},
-    'icon': {'base_url': 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{0}/{1}.jpg', 'fallback_media': None},
-    'clearlogo': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/logo.png', 'fallback_media': None}  # No fallback possible for clearlogo
+ARTS_DATA = {  # img_icon_path is a path provided by steam to get the icon. https://developer.valvesoftware.com/wiki/Steam_Web_API#GetOwnedGames_.28v0001.29
+    'poster': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_600x900.jpg', 'fallback_media': 'landscape'},  # Can return 404
+    'banner': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_hero.jpg', 'fallback_media': 'landscape'},  # Can return 404
+    'landscape': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg', 'fallback_media': None},
+    'thumb': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg', 'fallback_media': None},
+    'fanart': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_hero.jpg', 'fallback_media': 'fanart2'},  # Can return 404
+    'fanart2': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg', 'fallback_media': 'fanart3'},
+    'fanart3': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/page_bg_generated_v6b.jpg', 'fallback_media': None},
+    'icon': {'base_url': 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{appid}/{img_icon_path}.jpg', 'fallback_media': None},
+    'clearlogo': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/logo.png', 'fallback_media': None}  # Can return 404
 }
 
 
 def is_art_url_available(url, timeout=2):
     """
-    Sends a HEAD request to check if an online resource is available. Uses a cache mechanism to speed things up or serve offline.
+    Sends a HEAD request to check if an online resource is available. Uses a cache mechanism to speed things up or serve offline if a connection is unavailable.
 
     :param url: url to check availability
-    :param timeout: timeout of the request in seconds. Default 2
+    :param timeout: timeout of the request in seconds. Default is 2
     :return: boolean False if the status code is between 400&600 , True otherwise
     """
     result = False
     try:
         response = cached_requests.head(url, timeout=timeout)
-        if not 400 <= response.status_code < 600:  # We consider valid any status codes belwo 400 or above 600
+        if not 400 <= response.status_code < 600:  # We consider valid any status codes below 400 or above 600
             result = True
     except IOError:
         result = False
     return result
 
 
-def resolve_media_url(media_type, appid, img_icon_path=''):
-    valid_media_url = None
+def resolve_art_url(art_type, appid, img_icon_path='', art_fallback_enabled=artFallbackEnabled):
+    """
+    Resolve the art url of a specified game/app, for a given art type defined in the :const:`ARTS_DATA` dictionary.
+    Handles fallback to another art type if needed (ie the requested one is unavailable and fallback is enabled).
 
-    art_data = arts_urls.get(media_type, None)
+    :param art_type: a valid art type, defined in :const:`ARTS_DATA`
+    :param appid: appid of the game/app we want to get the art for.
+    :param img_icon_path: A path provided by steam to get the icon art url. https://developer.valvesoftware.com/wiki/Steam_Web_API#GetOwnedGames_.28v0001.29
+    :param art_fallback_enabled: Whether to fall back to another art type if an art is unavailable. Defaults to the user addon settings, which default to true
+    :return: resolved art URL. Can be the URL of another available art if .
+    """
+    valid_art_url = None
+    requested_art_data = ARTS_DATA.get(art_type, None)
 
-    while valid_media_url is None and art_data is not None:
-        art_url = art_data.get('base_url').format(appid, img_icon_path)
-        if not enableArtFallback or is_art_url_available(art_url):
-            # If art fallback is disabled, we directly assume the art url as valid.
-            # If art fallback is enabled, we check if the art is available before proceeding
-            valid_media_url = art_url
-        else:
-            # If the art is not available (and art fallback is enabled) we try with the defined fallback
-            fallback_media_type = art_data.get("fallback", None)
-            art_data = arts_urls.get(fallback_media_type, None)
+    while valid_art_url is None and requested_art_data is not None:  # If the current media type is defined and we did not find a valid url yet
+        art_url = requested_art_data.get('base_url').format(appid=appid, img_icon_path=img_icon_path)  # We replace "{appid}" and "{img_icon_path}" in the url
+        fallback_art_type = requested_art_data.get("fallback_media", None)
+        if (not art_fallback_enabled) or (fallback_art_type is None) or is_art_url_available(art_url):
+            # If art fallback is disabled, or if there is no fallback defined, we directly assume the art url as valid.
+            # Otherwise, if art fallback is enabled and there is a fallback defined, we check if is_art_url_available before proceeding
+            valid_art_url = art_url
+        else:  # If art fallback is enabled and art is not available, we set the current art data to the defined fallback, before retrying.
+            requested_art_data = ARTS_DATA.get(fallback_art_type, None)  # Art data will be None if the fallback_art_type does not exist in the art_urls dict
 
-    if valid_media_url is None:
-        show_error(None, "Issue obtaining a media", False)
+    if valid_art_url is None:  # If the previous loop could not find a valid media url among the defined art types
+        show_error(None, "Issue obtaining a media", display_notification=False)
         return
 
-    return valid_media_url
+    return valid_art_url
 
 
 def delete_cache():
+    """
+    Deletes the cache containing the data about which art types are available or not
+    """
     os.remove(ART_AVAILABILITY_CACHE_FILE + ".sqlite")

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -1,0 +1,71 @@
+import xbmc
+import xbmcaddon
+
+import os
+import requests
+import requests_cache
+
+from util import show_error
+
+# define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
+addonUserDataFolder = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
+art_availability_cache_file = xbmc.translatePath(os.path.join(addonUserDataFolder, 'requests_cache_arts'))
+
+# cache expires after: 86400=1 day   604800=7 days
+cached_requests = requests_cache.core.CachedSession(art_availability_cache_file, backend='sqlite',
+                                                    expire_after=604800 * 2,
+                                                    allowable_methods=('HEAD',),
+                                                    allowable_codes=(200, 404),
+                                                    old_data_on_error=True)
+
+# Todo : tweak fallbacks and arts to have the best look in Kodi
+#  TODO note which are safe to use and which can be missing
+
+# Dictionary containing for each art type, a base_url for the art (to format with appid / img_icon_path afterwards), and a fallback art type.
+arts_urls = {  # {0} is appid, {1} is a special path provided by steam api for the icon
+    'poster': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_600x900.jpg', 'fallback_media': 'landscape'},
+    'landscape': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}//header.jpg', 'fallback_media': 'thumb'},
+    'banner': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_hero.jpg', 'fallback_media': 'thumb'},
+    'thumb': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': 'fanart'},
+    'fanart': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/page_bg_generated_v6b.jpg', 'fallback_media': None},
+    'icon': {'base_url': 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{0}/{1}.jpg', 'fallback_media': None},
+    'clearlogo': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/logo.png', 'fallback_media': None}  # No fallback possible for clearlogo
+}
+
+
+def is_art_url_available(url, timeout=2):
+    """
+    Sends a HEAD request to check if an online resource is available. Uses a cache mechanism to speed things up or serve offline.
+
+    :param url: url to check availability
+    :param timeout: timeout of the request in seconds. Default 2
+    :return: boolean False if the status code is between 400&600 , True otherwise
+    """
+    result = False
+    try:
+        response = cached_requests.head(url, timeout=timeout)
+        if not 400 <= response.status_code < 600:  # We consider valid any status codes belwo 400 or above 600
+            result = True
+    except IOError:
+        result = False
+    return result
+
+
+def resolve_media_url(media_type, appid, img_icon_path=''):
+    valid_media_url = None
+
+    art_data = arts_urls.get(media_type, None)
+
+    while valid_media_url is None and art_data is not None:
+        art_url = art_data.get('base_url').format(appid, img_icon_path)
+        if is_art_url_available(art_url):
+            valid_media_url = art_url
+        else:
+            fallback_media_type = art_data.get("fallback", None)
+            art_data = arts_urls.get(fallback_media_type, None)
+
+    if valid_media_url is None:
+        show_error(None, "Issue obtaining a media", False)
+        return
+
+    return valid_media_url

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -1,12 +1,9 @@
-import sys
-
 import xbmc
 import xbmcaddon
 
 import os
 import requests
 import requests_cache
-import xbmcplugin
 
 from util import show_error
 

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -1,19 +1,22 @@
+import sys
+
 import xbmc
 import xbmcaddon
 
 import os
 import requests
 import requests_cache
+import xbmcplugin
 
 from util import show_error
 
 # define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
 addonUserDataFolder = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
 ART_AVAILABILITY_CACHE_FILE = xbmc.translatePath(os.path.join(addonUserDataFolder, 'requests_cache_arts'))
+minutesBeforeArtsExpiration = int(xbmcplugin.getSetting(int(sys.argv[1]), "arts-expire-after-minutes"))  # Default is 1month
 
-# cache expires after: 86400=1 day   604800=7 days
 cached_requests = requests_cache.core.CachedSession(ART_AVAILABILITY_CACHE_FILE, backend='sqlite',
-                                                    expire_after=604800 * 2,
+                                                    expire_after=60 * minutesBeforeArtsExpiration,
                                                     allowable_methods=('HEAD',),
                                                     allowable_codes=(200, 404),
                                                     old_data_on_error=True)

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -9,7 +9,7 @@ from util import show_error
 
 __addon__ = xbmcaddon.Addon()
 enableArtFallback = __addon__.getSetting("enable-art-fallback") == 'true'  # Kodi stores boolean settings as strings
-minutesBeforeArtsExpiration = int(__addon__.getSetting("arts-expire-after-minutes"))  # Default is 1month
+minutesBeforeArtsExpiration = int(__addon__.getSetting("arts-expire-after-minutes"))  # Default is 2 months
 
 # define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
 addonUserDataFolder = xbmc.translatePath(__addon__.getAddonInfo('profile'))

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -9,10 +9,10 @@ from util import show_error
 
 # define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
 addonUserDataFolder = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
-art_availability_cache_file = xbmc.translatePath(os.path.join(addonUserDataFolder, 'requests_cache_arts'))
+ART_AVAILABILITY_CACHE_FILE = xbmc.translatePath(os.path.join(addonUserDataFolder, 'requests_cache_arts'))
 
 # cache expires after: 86400=1 day   604800=7 days
-cached_requests = requests_cache.core.CachedSession(art_availability_cache_file, backend='sqlite',
+cached_requests = requests_cache.core.CachedSession(ART_AVAILABILITY_CACHE_FILE, backend='sqlite',
                                                     expire_after=604800 * 2,
                                                     allowable_methods=('HEAD',),
                                                     allowable_codes=(200, 404),
@@ -69,3 +69,7 @@ def resolve_media_url(media_type, appid, img_icon_path=''):
         return
 
     return valid_media_url
+
+
+def delete_cache():
+    os.remove(ART_AVAILABILITY_CACHE_FILE + ".sqlite")

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -27,10 +27,12 @@ cached_requests = requests_cache.core.CachedSession(ART_AVAILABILITY_CACHE_FILE,
 # Dictionary containing for each art type, a base_url for the art (to format with appid / img_icon_path afterwards), and a fallback art type.
 arts_urls = {  # {0} is appid, {1} is a special path provided by steam api for the icon
     'poster': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_600x900.jpg', 'fallback_media': 'landscape'},
-    'landscape': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}//header.jpg', 'fallback_media': 'thumb'},
-    'banner': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_hero.jpg', 'fallback_media': 'thumb'},
-    'thumb': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': 'fanart'},
-    'fanart': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/page_bg_generated_v6b.jpg', 'fallback_media': None},
+    'banner': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_hero.jpg', 'fallback_media': 'landscape'},
+    'landscape': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': None},
+    'thumb': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': None},
+    'fanart': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/library_hero.jpg', 'fallback_media': 'fanart2'},
+    'fanart2': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/header.jpg', 'fallback_media': 'fanart3'},
+    'fanart3': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/page_bg_generated_v6b.jpg', 'fallback_media': None},
     'icon': {'base_url': 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{0}/{1}.jpg', 'fallback_media': None},
     'clearlogo': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{0}/logo.png', 'fallback_media': None}  # No fallback possible for clearlogo
 }

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -20,18 +20,28 @@ cached_requests = requests_cache.core.CachedSession(ART_AVAILABILITY_CACHE_FILE,
                                                     allowable_methods=('HEAD',), allowable_codes=(200, 404),
                                                     old_data_on_error=True,
                                                     fast_save=True)
+# Existing Steam art types urls, to format to format with appid / img_icon_path
+STEAM_ARTS_TYPES = {  # img_icon_path is provided by steam API to get the icon. https://developer.valvesoftware.com/wiki/Steam_Web_API#GetOwnedGames_.28v0001.29
+    'poster': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_600x900.jpg',  # Can return 404
+    'hero': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_hero.jpg',  # Can return 404
+    'header': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg',
+    'generated_bg': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/page_bg_generated_v6b.jpg',  # Auto generated background with a shade of blue.
+    'icon': 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{appid}/{img_icon_path}.jpg',
+    'logo': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/logo.png'  # Can return 404
+}
 
-# Dictionary containing for each art type, a base_url for the art (to format with appid / img_icon_path afterwards), and a fallback art type.
-ARTS_DATA = {  # img_icon_path is a path provided by steam to get the icon. https://developer.valvesoftware.com/wiki/Steam_Web_API#GetOwnedGames_.28v0001.29
-    'poster': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_600x900.jpg', 'fallback_media': 'landscape'},  # Can return 404
-    'banner': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_hero.jpg', 'fallback_media': 'landscape'},  # Can return 404
-    'landscape': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg', 'fallback_media': None},
-    'thumb': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg', 'fallback_media': None},
-    'fanart': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/library_hero.jpg', 'fallback_media': 'fanart2'},  # Can return 404
-    'fanart2': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg', 'fallback_media': 'fanart3'},
-    'fanart3': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/page_bg_generated_v6b.jpg', 'fallback_media': None},
-    'icon': {'base_url': 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/{appid}/{img_icon_path}.jpg', 'fallback_media': None},
-    'clearlogo': {'base_url': 'http://cdn.akamai.steamstatic.com/steam/apps/{appid}/logo.png', 'fallback_media': None}  # Can return 404
+# Dictionary containing for each art type, a url for the art (to format with appid / img_icon_path afterwards), and a fallback art type.
+# Having no fallback also means that the art url won't be tested
+ARTS_ASSIGNMENTS = {
+    'poster': {'url': STEAM_ARTS_TYPES['poster'], 'fallback': 'landscape'},
+    'banner': {'url': STEAM_ARTS_TYPES['hero'], 'fallback': 'landscape'},
+    'fanart': {'url': STEAM_ARTS_TYPES['hero'], 'fallback': 'fanart1'},
+    'fanart1': {'url': STEAM_ARTS_TYPES['header'], 'fallback': None},
+    'fanart2': {'url': STEAM_ARTS_TYPES['generated_bg'], 'fallback': None},  # Multiple fanart https://kodi.wiki/view/Artwork_types#fanart.23
+    'landscape': {'url': STEAM_ARTS_TYPES['header'], 'fallback': None},
+    'thumb': {'url': STEAM_ARTS_TYPES['header'], 'fallback': None},
+    'icon': {'url': STEAM_ARTS_TYPES['icon'], 'fallback': None},
+    'clearlogo': {'url': STEAM_ARTS_TYPES['logo'], 'fallback': None}
 }
 
 
@@ -65,17 +75,17 @@ def resolve_art_url(art_type, appid, img_icon_path='', art_fallback_enabled=artF
     :return: resolved art URL. Can be the URL of another available art if .
     """
     valid_art_url = None
-    requested_art_data = ARTS_DATA.get(art_type, None)
+    requested_art = ARTS_ASSIGNMENTS.get(art_type, None)
 
-    while valid_art_url is None and requested_art_data is not None:  # If the current media type is defined and we did not find a valid url yet
-        art_url = requested_art_data.get('base_url').format(appid=appid, img_icon_path=img_icon_path)  # We replace "{appid}" and "{img_icon_path}" in the url
-        fallback_art_type = requested_art_data.get("fallback_media", None)
+    while valid_art_url is None and requested_art is not None:  # If the current media type is defined and we did not find a valid url yet
+        art_url = requested_art.get('url').format(appid=appid, img_icon_path=img_icon_path)  # We replace "{appid}" and "{img_icon_path}" in the url
+        fallback_art_type = requested_art.get("fallback", None)
         if (not art_fallback_enabled) or (fallback_art_type is None) or is_art_url_available(art_url):
             # If art fallback is disabled, or if there is no fallback defined, we directly assume the art url as valid.
             # Otherwise, if art fallback is enabled and there is a fallback defined, we check if is_art_url_available before proceeding
             valid_art_url = art_url
         else:  # If art fallback is enabled and art is not available, we set the current art data to the defined fallback, before retrying.
-            requested_art_data = ARTS_DATA.get(fallback_art_type, None)  # Art data will be None if the fallback_art_type does not exist in the art_urls dict
+            requested_art = ARTS_ASSIGNMENTS.get(fallback_art_type, None)  # Art data will be None if the fallback_art_type does not exist in the art_urls dict
 
     if valid_art_url is None:  # If the previous loop could not find a valid media url among the defined art types
         show_error(None, "Issue obtaining a media", display_notification=False)

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -5,7 +5,7 @@ import os
 import requests
 import requests_cache
 
-from util import show_error
+from util import log
 
 __addon__ = xbmcaddon.Addon()
 artFallbackEnabled = __addon__.getSetting("enable-art-fallback") == 'true'  # Kodi stores boolean settings as strings
@@ -88,8 +88,7 @@ def resolve_art_url(art_type, appid, img_icon_path='', art_fallback_enabled=artF
             requested_art = ARTS_ASSIGNMENTS.get(fallback_art_type, None)  # Art data will be None if the fallback_art_type does not exist in the art_urls dict
 
     if valid_art_url is None:  # If the previous loop could not find a valid media url among the defined art types
-        show_error(None, "Issue obtaining a media", display_notification=False)
-        return
+        log("Issue resolving media {0} for app id {1}".format(art_type, appid))
 
     return valid_art_url
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -2,6 +2,8 @@ import os
 import routing
 import sys
 import xbmcplugin
+
+import arts
 import registry
 import steam
 from util import *
@@ -143,11 +145,21 @@ def create_directory_items(app_entries):
 def create_arts_dictionary(app_entry):
     """
     Creates a dictionary of arts keys and their associated links, for a given app entry.
-    :param app_entry: dictionary of app informations, containing at least the keys : appid, img_icon_url, img_logo_url
+    :param app_entry: dictionary of app information, containing at least the keys : appid, img_icon_url, img_logo_url
     :return: dictionary of arts for the app.
     """
-    art_dictionary = {'thumb': 'http://cdn.akamai.steamstatic.com/steam/apps/' + str(app_entry['appid']) + '/header.jpg',
-                      'fanart': 'http://cdn.akamai.steamstatic.com/steam/apps/' + str(app_entry['appid']) + '/page_bg_generated_v6b.jpg'}
+
+    appid = str(app_entry['appid'])
+
+    art_dictionary = {
+        'poster': arts.resolve_media_url('poster', appid),  # plugin.url_for(resolve_media, media_type='poster', appid=appid),  # library asset, often missing
+        'landscape': arts.resolve_media_url('landscape', appid),  # plugin.url_for(resolve_media, media_type='landscape', appid=appid),
+        'banner': arts.resolve_media_url('banner', appid),  # plugin.url_for(resolve_media, media_type='banner', appid=appid),
+        'clearlogo': arts.resolve_media_url('clearlogo', appid),  # plugin.url_for(resolve_media, media_type='clearlogo', appid=appid),
+        'thumb': arts.resolve_media_url('thumb', appid),  # plugin.url_for(resolve_media, media_type='thumb', appid=appid),
+        'fanart': arts.resolve_media_url('fanart', appid),  # plugin.url_for(resolve_media, media_type='fanart', appid=appid),
+        'icon': arts.resolve_media_url('icon', appid, app_entry['img_icon_url'])
+    }
     return art_dictionary
 
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -116,6 +116,11 @@ def run(appid):
     steam.run(__addon__.getSetting('steam-exe'), __addon__.getSetting('steam-args'), appid)
 
 
+@plugin.route('/delete_cache')
+def delete_cache():
+    arts.delete_cache()
+
+
 def create_directory_items(app_entries):
     """
     Creates a list item for each game/app entry provided

--- a/resources/main.py
+++ b/resources/main.py
@@ -163,13 +163,13 @@ def create_arts_dictionary(app_entry):
     appid = str(app_entry['appid'])
 
     art_dictionary = {
-        'poster': arts.resolve_media_url('poster', appid),  # plugin.url_for(resolve_media, media_type='poster', appid=appid),  # library asset, often missing
-        'landscape': arts.resolve_media_url('landscape', appid),  # plugin.url_for(resolve_media, media_type='landscape', appid=appid),
-        'banner': arts.resolve_media_url('banner', appid),  # plugin.url_for(resolve_media, media_type='banner', appid=appid),
-        'clearlogo': arts.resolve_media_url('clearlogo', appid),  # plugin.url_for(resolve_media, media_type='clearlogo', appid=appid),
-        'thumb': arts.resolve_media_url('thumb', appid),  # plugin.url_for(resolve_media, media_type='thumb', appid=appid),
-        'fanart': arts.resolve_media_url('fanart', appid),  # plugin.url_for(resolve_media, media_type='fanart', appid=appid),
-        'icon': arts.resolve_media_url('icon', appid, app_entry['img_icon_url'])
+        'poster': arts.resolve_art_url('poster', appid),
+        'landscape': arts.resolve_art_url('landscape', appid),
+        'banner': arts.resolve_art_url('banner', appid),
+        'clearlogo': arts.resolve_art_url('clearlogo', appid),
+        'thumb': arts.resolve_art_url('thumb', appid),
+        'fanart': arts.resolve_art_url('fanart', appid),
+        'icon': arts.resolve_art_url('icon', appid, app_entry['img_icon_url'])
     }
     return art_dictionary
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -123,6 +123,11 @@ def create_directory_items(app_entries):
     :param app_entries: array of game entries, with each entry containing at least keys : appid, name, img_icon_url, img_logo_url, playtime_forever
     :returns: an array of list items of the game entries, formatted like so : [(url,listItem,bool),..]
     """
+
+    # We set the folder content to "movies" as the program/game contents are locked out of many useful views, such as posters, headers, and more.
+    xbmcplugin.setContent(plugin.handle, "movies")
+    # TODO setContent to games when more skins support this content type.
+
     directory_items = []
     for app_entry in app_entries:
         appid = str(app_entry['appid'])
@@ -132,7 +137,8 @@ def create_directory_items(app_entries):
         item = xbmcgui.ListItem(name)
 
         item.addContextMenuItems([('Play', 'RunPlugin(' + run_url + ')'),
-                                  ('Install', 'RunPlugin(' + plugin.url_for(install, appid=appid) + ')')])
+                                  ('Install', 'RunPlugin(' + plugin.url_for(install, appid=appid) + ')')],
+                                 replaceItems=True)  # Since we set the content type to "movies", default movie context elements may appear. We replace them.
 
         art_dictionary = create_arts_dictionary(app_entry)
         item.setArt(art_dictionary)

--- a/resources/main.py
+++ b/resources/main.py
@@ -161,16 +161,14 @@ def create_arts_dictionary(app_entry):
     """
 
     appid = str(app_entry['appid'])
+    img_icon_url = app_entry['img_icon_url']
+    art_dictionary = {}
 
-    art_dictionary = {
-        'poster': arts.resolve_art_url('poster', appid),
-        'landscape': arts.resolve_art_url('landscape', appid),
-        'banner': arts.resolve_art_url('banner', appid),
-        'clearlogo': arts.resolve_art_url('clearlogo', appid),
-        'thumb': arts.resolve_art_url('thumb', appid),
-        'fanart': arts.resolve_art_url('fanart', appid),
-        'icon': arts.resolve_art_url('icon', appid, app_entry['img_icon_url'])
-    }
+    # Multiple fanart https://kodi.wiki/view/Artwork_types#fanart.23
+    SUPPORTED_ART_TYPES = ['poster', 'landscape', 'banner', 'clearlogo', 'thumb', 'fanart', 'fanart1', 'fanart2', 'icon']
+
+    for art_type in SUPPORTED_ART_TYPES:
+        art_dictionary[art_type] = arts.resolve_art_url(art_type, appid, img_icon_url)
     return art_dictionary
 
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,6 +7,7 @@
     <setting id="steam-path" type="folder" label="Your Steam folder (contains registry.vdf)"/>
     <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
     <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
+    <setting id="enable-art-fallback" type="bool" default="true" label="Fallback to another art type if a game has missing art. First launch may be longer for large libraries."/>
     <setting id="arts-expire-after-minutes" type="number" default="43800" label="Number of minutes before expiration of the arts availability cache"/>
     <setting id="delete-cache"  type="action" label="Clean available games and arts cache" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)"/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,6 +8,6 @@
     <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
     <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
     <setting id="enable-art-fallback" type="bool" default="true" label="Fallback to another art type if a game has missing art. First launch may be longer for large libraries."/>
-    <setting id="arts-expire-after-minutes" type="number" default="87600" label="Number of minutes before expiration of the arts availability cache"/>
+    <setting id="arts-expire-after-months" type="number" default="2" label="Number of months before expiration of the arts availability cache"/>
     <setting id="delete-cache"  type="action" label="Clean available games and arts cache" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)"/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,5 +7,6 @@
     <setting id="steam-path" type="folder" label="Your Steam folder (contains registry.vdf)"/>
     <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
     <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
+    <setting id="arts-expire-after-minutes" type="number" default="43800" label="Number of minutes before expiration of the arts availability cache"/>
     <setting id="delete-cache"  type="action" label="Clean available games and arts cache" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)"/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,6 +8,6 @@
     <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
     <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
     <setting id="enable-art-fallback" type="bool" default="true" label="Fallback to another art type if a game has missing art. First launch may be longer for large libraries."/>
-    <setting id="arts-expire-after-minutes" type="number" default="43800" label="Number of minutes before expiration of the arts availability cache"/>
+    <setting id="arts-expire-after-minutes" type="number" default="87600" label="Number of minutes before expiration of the arts availability cache"/>
     <setting id="delete-cache"  type="action" label="Clean available games and arts cache" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)"/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,4 +7,5 @@
     <setting id="steam-path" type="folder" label="Your Steam folder (contains registry.vdf)"/>
     <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
     <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
+    <setting id="delete-cache"  type="action" label="Clean available games and arts cache" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)"/>
 </settings>

--- a/resources/util.py
+++ b/resources/util.py
@@ -1,3 +1,4 @@
+import requests
 import xbmc
 import xbmcaddon
 import xbmcgui
@@ -10,15 +11,17 @@ def log(msg, level=xbmc.LOGDEBUG):
         xbmc.log('[%s] %s' % (__addon__.getAddonInfo('id'), msg), level=level)
 
 
-def show_error(e, message):
+def show_error(e, message, display_notification=True):
     """ Displays an error message to the user and log the cause.
 
     :type e: Exception
     :param e: An exception object to add to the error log
     :param message: An error message to display to the user
+    :param display_notification: boolean indication whether or not an error notification is shown in Kodi
     """
-    notify = xbmcgui.Dialog()
-    notify.notification('Error', message, xbmcgui.NOTIFICATION_ERROR)
+    if display_notification:
+        notify = xbmcgui.Dialog()
+        notify.notification('Error', message, xbmcgui.NOTIFICATION_ERROR)
     log(str(e), xbmc.LOGERROR)
 
 

--- a/resources/util.py
+++ b/resources/util.py
@@ -1,4 +1,3 @@
-import requests
 import xbmc
 import xbmcaddon
 import xbmcgui


### PR DESCRIPTION
A few arts types like games posters and hero graphics came with the last Steam library overhaul. [Relevant Steam docs](https://partner.steamgames.com/doc/store/assets/libraryassets)
Developers added these library assets since then, but some old games don't have these available (yet ? ). [SteamDB pages](https://steamdb.info/app/620/info/#info) have available arts listed

- [x] The games now have many art types, from Steam's [posters](https://steamcdn-a.akamaihd.net/steam/apps/620/library_600x900.jpg) , [hero graphics](https://steamcdn-a.akamaihd.net/steam/apps/620/library_hero.jpg) , [clearlogos](https://steamcdn-a.akamaihd.net/steam/apps/620/logo.png) , along with the previously implemented [headers](https://steamcdn-a.akamaihd.net/steam/apps/620/header.jpg), and our very dears [ugly bluish autogenerated backgrounds](http://cdn.akamai.steamstatic.com/steam/apps/620/page_bg_generated_v6b.jpg)

~Forcing additional views as available would be an interesting addition, as skins usually control which views are available for which content~
- [x] By telling skins that we provide movies content, we have access to all the movies views, such as Poster views, landscape, clearlogos, etc, that are not available for game/program content. This workaround could be removed once skin support for game content is better.

- [x] If an art is not available, and a fallback is defined (in arts.py>ARTS_DATA), we tries to fallback to it. To do that, the plugin sends and caches HEAD requests to the Steam CDN URLs of the available art types, and if unavailable, does the same with the fallback art instead. 
Due to this, the first launch can be longer, especially for large libraries, but subsequent ones are fast as they use the cached data. Through the addon settings, the cache can be cleaned, and the expiration delay can be user configured (defaults to 2 months since arts are rarely added.). Art fallback can be disabled altogether, too. 

Basically, HEAD requests are done when : the art fallback setting is enabled AND the art we are looking for has a fallback specified. As of now, fallbacks are set for [library posters](https://steamcdn-a.akamaihd.net/steam/apps/620/library_600x900.jpg) and [hero graphics](https://steamcdn-a.akamaihd.net/steam/apps/620/library_hero.jpg), as they are not present on all games. Clearlogo can also be missing, but I did not define a fallback for it. (I could probably fallback to jpg [standard logos](https://steamcdn-a.akamaihd.net/steamcommunity/public/images/apps/620/d2a1119ddc202fab81d9b87048f495cbd6377502.jpg), but with first load times in mind I decided against it.)

Caching uses the module [requests-cache](https://requests-cache.readthedocs.io/en/latest/user_guide.html#usage)

### Screenshots

Poster wall using the skin Arctic Zephyr 2 (Note that "Nosferatu[...]" doesn't have a poster and used the header as a fallback - it is not that great considering how it was fit but better than a black rectangle) 
![image](https://user-images.githubusercontent.com/15179425/80932964-037e4480-8dc2-11ea-8bfe-dccd84dbae17.png)

Posters using Estuary (Estuary does a better job at fitting the picture when a poster is unavailable, and adds the game title below it in this case, which is nice too)
![image](https://user-images.githubusercontent.com/15179425/80933180-dd0cd900-8dc2-11ea-86da-ec2291d8e2eb.png)


Landscape Wall w/ Arctic Zephyr 2
![image](https://user-images.githubusercontent.com/15179425/81138340-fd26ce80-8f61-11ea-8d01-5b4b4d47a8a4.png)


Banner List w/ Arctic Zephyr 2
![image](https://user-images.githubusercontent.com/15179425/80932921-d336a600-8dc1-11ea-8f11-ea000b0c7bc2.png)
