### PR TITLE
Additional information and sorting method for games (play time)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -47,5 +47,6 @@
             <screenshot>resources/screenshot-03.jpg</screenshot>
             <screenshot>resources/screenshot-04.jpg</screenshot>
         </assets>
+        <source>https://github.com/aanderse/plugin.program.steam.library</source>
     </extension>
 </addon>

--- a/resources/main.py
+++ b/resources/main.py
@@ -134,6 +134,7 @@ def create_directory_items(app_entries):
         item = xbmcgui.ListItem(name)
         item.setUniqueIDs({'steam': appid, 'steam_img_icon': app_entry['img_icon_url']})
         item.setInfo('video', {'playcount': app_entry.get('playtime_forever', 0)})
+        item.setContentLookup(False)  # Tells Kodi not to send HEAD requests (used to determine MIME type for example) to the item's run URL.
 
         item.addContextMenuItems([('Play', 'RunPlugin(' + run_url + ')'),
                                   ('Install', 'RunPlugin(' + plugin.url_for(install, appid=appid) + ')')])

--- a/resources/main.py
+++ b/resources/main.py
@@ -39,6 +39,7 @@ def all_games():
     xbmcplugin.addDirectoryItems(plugin.handle, directory_items)
 
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_PLAYCOUNT)
     xbmcplugin.endOfDirectory(plugin.handle, succeeded=True)
 
 
@@ -70,6 +71,7 @@ def installed_games():
     xbmcplugin.addDirectoryItems(plugin.handle, directory_items)
 
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_PLAYCOUNT)
     xbmcplugin.endOfDirectory(plugin.handle, succeeded=True)
 
 
@@ -90,7 +92,9 @@ def recent_games():
     directory_items = create_directory_items(steam_games_details)
     xbmcplugin.addDirectoryItems(plugin.handle, directory_items)
 
-    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED, "Last played")
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_PLAYCOUNT)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.endOfDirectory(plugin.handle, succeeded=True)
 
 
@@ -128,6 +132,8 @@ def create_directory_items(app_entries):
 
         run_url = plugin.url_for(run, appid=appid)
         item = xbmcgui.ListItem(name)
+        item.setUniqueIDs({'steam': appid, 'steam_img_icon': app_entry['img_icon_url']})
+        item.setInfo('video', {'playcount': app_entry.get('playtime_forever', 0)})
 
         item.addContextMenuItems([('Play', 'RunPlugin(' + run_url + ')'),
                                   ('Install', 'RunPlugin(' + plugin.url_for(install, appid=appid) + ')')])


### PR DESCRIPTION
- [x] Added uniqueIds to list items : the steam app id.

- [x] Added play time information to list items since it is provided by the used API call. 

- [x] Consequently added sorting methods for games : Sorting by play time is now possible.