### PR TITLE
Allow offline support through a caching mechanism of the Steam games lists

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="2.19.0" />
         <import addon="script.module.requests" version="2.18.4" />
+        <import addon="script.module.requests-cache" version="0.4.13" />
         <import addon="script.module.routing" version="0.2.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon.py">

--- a/resources/main.py
+++ b/resources/main.py
@@ -114,6 +114,11 @@ def run(appid):
     steam.run(__addon__.getSetting('steam-exe'), __addon__.getSetting('steam-args'), appid)
 
 
+@plugin.route('/delete_cache')
+def delete_cache():
+    steam.delete_cache()
+
+
 def create_directory_items(app_entries):
     """
     Creates a list item for each game/app entry provided

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,4 +7,6 @@
     <setting id="steam-path" type="folder" label="Your Steam folder (contains registry.vdf)"/>
     <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
     <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
+    <setting id="games-expire-after-minutes" type="number" default="10080" label="Number of minutes before expiration of the games lists cache"/>
+    <setting id="delete-cache" type="action" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)" label="Clean available arts and games cache"/>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,6 +7,6 @@
     <setting id="steam-path" type="folder" label="Your Steam folder (contains registry.vdf)"/>
     <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
     <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
-    <setting id="games-expire-after-minutes" type="number" default="10080" label="Number of minutes before expiration of the games lists cache"/>
+    <setting id="games-expire-after-minutes" type="number" default="4320" label="Number of minutes before expiration of the games lists cache"/>
     <setting id="delete-cache" type="action" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)" label="Clean available arts and games cache"/>
 </settings>

--- a/resources/steam.py
+++ b/resources/steam.py
@@ -1,8 +1,27 @@
+import os
+import sys
 import shlex
 import subprocess
+
+import xbmc
+import xbmcaddon
+import xbmcplugin
+
 import requests
+import requests_cache
 
 from util import log
+
+__addon__ = xbmcaddon.Addon()
+# define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
+addonUserDataFolder = xbmc.translatePath(__addon__.getAddonInfo('profile'))
+STEAM_GAMES_CACHE_FILE = xbmc.translatePath(os.path.join(addonUserDataFolder, 'requests_cache_games'))
+minutesBeforeGamesListsExpiration = int(xbmcplugin.getSetting(int(sys.argv[1]), "games-expire-after-minutes"))  # Default is 7 days
+
+# cache expires after: 86400=1 day   604800=7 days
+cached_requests = requests_cache.core.CachedSession(STEAM_GAMES_CACHE_FILE, backend='sqlite',
+                                                    expire_after=60 * minutesBeforeGamesListsExpiration,
+                                                    old_data_on_error=True)
 
 
 def install(steam_exe_path, appid):
@@ -29,7 +48,7 @@ def run(steam_exe_path, steam_launch_args, appid):
     log('executing ' + steam_exe_path + ' ' + steam_launch_args + ' steam://rungameid/' + appid)
 
     # https://developer.valvesoftware.com/wiki/Steam_browser_protocol
-    subprocess.call([steam_exe_path] + user_args + ['steam://rungameid/' + appid]) #Concatenate the arrays into one
+    subprocess.call([steam_exe_path] + user_args + ['steam://rungameid/' + appid])  # Concatenate the arrays into one
 
 
 def get_user_games(steam_api_key, steam_user_id, recent_only=False):
@@ -73,13 +92,17 @@ def get_user_games(steam_api_key, steam_user_id, recent_only=False):
         api_url = 'https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/'
 
     # We send a request to the API, including needed parameters and "include_appinfo" so that game details are returned with the response.
-    response = requests.get(url=api_url,
-                            params={'key': steam_api_key,
-                                    'steamid': steam_user_id,
-                                    'include_appinfo': 1,
-                                    'format': 'json'},
-                            timeout=10)
+    response = cached_requests.get(url=api_url,
+                                   params={'key': steam_api_key,
+                                           'steamid': steam_user_id,
+                                           'include_appinfo': 1,
+                                           'format': 'json'},
+                                   timeout=10)
 
     response.raise_for_status()  # If the status code indicates an error, raise a HTTPError, which is itself a RequestException, based on the builtin IOError
     response_data = response.json().get('response', {})
     return response_data.get('games', {})
+
+
+def delete_cache():
+    os.remove(STEAM_GAMES_CACHE_FILE + ".sqlite")

--- a/resources/steam.py
+++ b/resources/steam.py
@@ -16,7 +16,7 @@ __addon__ = xbmcaddon.Addon()
 # define the cache file to reside in the ..\Kodi\userdata\addon_data\(your addon)
 addonUserDataFolder = xbmc.translatePath(__addon__.getAddonInfo('profile'))
 STEAM_GAMES_CACHE_FILE = xbmc.translatePath(os.path.join(addonUserDataFolder, 'requests_cache_games'))
-minutesBeforeGamesListsExpiration = int(xbmcplugin.getSetting(int(sys.argv[1]), "games-expire-after-minutes"))  # Default is 7 days
+minutesBeforeGamesListsExpiration = int(xbmcplugin.getSetting(int(sys.argv[1]), "games-expire-after-minutes"))  # Default is 3 days
 
 # cache expires after: 86400=1 day   604800=7 days
 cached_requests = requests_cache.core.CachedSession(STEAM_GAMES_CACHE_FILE, backend='sqlite',

--- a/resources/steam.py
+++ b/resources/steam.py
@@ -97,7 +97,7 @@ def get_user_games(steam_api_key, steam_user_id, recent_only=False):
                                            'steamid': steam_user_id,
                                            'include_appinfo': 1,
                                            'format': 'json'},
-                                   timeout=10)
+                                   timeout=5)
 
     response.raise_for_status()  # If the status code indicates an error, raise a HTTPError, which is itself a RequestException, based on the builtin IOError
     response_data = response.json().get('response', {})


### PR DESCRIPTION
By caching the Steam API calls & responses, and using cached responses on network errors, this enables offline support if a folder was already opened online once before.

The cached responses are used instead of the network calls, until they expire (3 days by default). unless there was a network error, in which case we use the cached responses regardless of their expiration. 

This uses the module [requests-cache](https://requests-cache.readthedocs.io/en/latest/user_guide.html#usage)


Along with the art lists caching mechanism (which caches the urls of available arts), Kodi's own cache (which caches the arts and items themselves), this should be good to go for full offline support.