### PR TITLE
0.7.0 Release changelog, and addon settings sorted into different categories.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -39,6 +39,10 @@
             v0.6.3 (2020-03-08)
             - various bug fixes thanks to @AmineI
             - add plugin to games provider list
+            v0.7.0 (2020-05-06)
+            - added support for more arts types and views for games, such as posters
+            - added play time information and sorting games by play time
+            - Offline support of the game lists, with a caching mechanism of the Steam API responses
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/resources/main.py
+++ b/resources/main.py
@@ -230,7 +230,7 @@ def main():
 
     if __addon__.getSetting('version') == '':
         # first time run, store version
-        __addon__.setSetting('version', '0.6.0')
+        __addon__.setSetting('version', __addon__.getAddonInfo('version'))
 
     # prompt the user to configure the plugin with their steam details
     if not all_required_credentials_available():

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,14 +1,24 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting id="debug" type="bool" label="Enable debugging mode" default="false"/>
-    <setting id="steam-id" type="text" label="Your Steam user id"/>
-    <setting id="steam-key" type="text" label="Your Steam web API key"/>
-    <setting id="steam-exe" type="executable" label="Your Steam executable file (Steam.exe)"/>
-    <setting id="steam-path" type="folder" label="Your Steam folder (contains registry.vdf)"/>
-    <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
-    <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
-    <setting id="enable-art-fallback" type="bool" default="true" label="Fallback to another art type if a game has missing art. First launch may be longer for large libraries."/>
-    <setting id="games-expire-after-minutes" type="number" default="4320" label="Number of minutes before expiration of the games lists cache"/>
-    <setting id="arts-expire-after-months" type="number" default="2" label="Number of months before expiration of the arts availability cache"/>
-    <setting id="delete-cache"  type="action" label="Clean available games and arts cache" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)"/>
+    <category label="Required Steam Details">
+        <setting id="steam-id" type="text" label="Your Steam user id"/>
+        <setting id="steam-key" type="text" label="Your Steam web API key"/>
+        <setting id="steam-exe" type="executable" label="Your Steam executable file (Steam.exe)"/>
+        <setting id="steam-path" type="folder" label="Your Steam folder (contains registry.vdf)"/>
+        <setting id="steam-args" type="text" label="Arguments to pass to your Steam executable"/>
+    </category>
+    <category label="Cache Management">
+        <setting id="games-expire-after-minutes" type="number" default="4320"
+                 label="Number of minutes before expiration of the games lists cache"/>
+        <setting id="arts-expire-after-months" type="number" default="2"
+                 label="Number of months before expiration of the arts availability cache"/>
+        <setting id="delete-cache" type="action" action="RunPlugin(plugin://plugin.program.steam.library/delete_cache)"
+                 label="Clean available games and arts cache"/>
+    </category>
+    <category label="Debugging">
+        <setting id="debug" type="bool" label="Enable debugging mode" default="false"/>
+        <setting id="enable-art-fallback" type="bool" default="true"
+                 label="Fallback to another art type if a game has missing art. First launch may be longer for large libraries."/>
+        <setting id="version" type="text" label="Internal version number, do not modify" visible="false"/>
+    </category>
 </settings>


### PR DESCRIPTION
A last small improvement for 0.7.0, along with the changelog, which should make it ready to ship as a release :) !

- Added changelog for 0.7.0
- Separated addon settings into different categories
- On first run, the version number is obtained programmatically, instead of being hardcoded in main.py

I also created a draft release on github, with the same changelog included in this PR's addon.xml 
If you're okay with it (Hopefully you can see it on your end, it should be saved on the repo but I never tried) it can be published as soon as this PR is merged 🎉 