### PR TITLE
Implement addon upgrade mechanism & improve delete cache reliability

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,8 +2,8 @@
 <addon id="plugin.program.steam.library" name="Steam Library" version="0.8.1" provider-name="aanderse">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
-        <import addon="script.module.requests" version="2.18.4" />
-        <import addon="script.module.requests-cache" version="0.4.13" />
+        <import addon="script.module.requests" version="2.22.0" />
+        <import addon="script.module.requests-cache" version="0.5.2" />
         <import addon="script.module.routing" version="0.2.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon.py">

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.steam.library" name="Steam Library" version="0.8.0" provider-name="aanderse">
+<addon id="plugin.program.steam.library" name="Steam Library" version="0.8.1" provider-name="aanderse">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" version="2.18.4" />

--- a/resources/arts.py
+++ b/resources/arts.py
@@ -98,4 +98,14 @@ def delete_cache():
     """
     Deletes the cache containing the data about which art types are available or not
     """
-    os.remove(ART_AVAILABILITY_CACHE_FILE + ".sqlite")
+    # If Kodi's request-cache module is updated to >0.7.3 , we will only need to issue cached_requests.cache.clear() which will handle all scenarios. Until then, we must recreate the backend ourselves    
+    try:
+        cached_requests.cache.clear()
+    except Exception:
+        log('Failed to clear cache. Attempting manual deletion')
+        try:
+            os.remove(ART_AVAILABILITY_CACHE_FILE + ".sqlite")
+        except:
+            log('Failed to delete cache file')
+        cached_requests.cache.responses = requests_cache.backends.storage.dbdict.DbPickleDict(ART_AVAILABILITY_CACHE_FILE + ".sqlite", 'responses', fast_save=True)
+        cached_requests.cache.keys_map = requests_cache.backends.storage.dbdict.DbDict(ART_AVAILABILITY_CACHE_FILE + ".sqlite", 'urls')

--- a/resources/main.py
+++ b/resources/main.py
@@ -232,6 +232,22 @@ def main():
         # first time run, store version
         __addon__.setSetting('version', __addon__.getAddonInfo('version'))
 
+    else:
+        previous_version= __addon__.getSetting('version').split(".")
+        previous_version= list(map(int, previous_version))
+
+        new_version= __addon__.getSetting('version').split(".")
+        new_version= list(map(int,new_version))
+
+        if previous_version[0] == 0 & previous_version[1] < 8:
+            #Starting with 0.8.0, the cache encoding changed and previous caches needs to be reset.
+            delete_cache()
+
+        # Insert version upgrade mechanisms here before the following call
+
+        __addon__.setSetting('version', __addon__.getAddonInfo('version'))
+
+
     # prompt the user to configure the plugin with their steam details
     if not all_required_credentials_available():
         __addon__.openSettings()


### PR DESCRIPTION
As mentioned in #30 , when updating from Kodi <19 we need to reset the caches. 
The update mechanism now properly does that and updates the version key stored in the settings.xml.
 
This cache deletion scenario causes issues on the latest available request-cache module version from the Kodi repo. (The database gets recreated without its tables) so the delete_cache methods had to be updated.  

I tested this on Windows with Kodi 19. Note that updating to this version of the addon will delete cache on first start, and that triggering cache deletion can still be done manually through the add-on settings